### PR TITLE
feat: add dynamic version flag injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ BINARY_NAME=gitx
 CMD_PATH=./cmd/gitx
 BUILD_DIR=./build
 
+# Versioning -- NEW SECTION
+# Get the latest git tag, or fallback to "dev" if no tags are found.
+VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+LDFLAGS := -ldflags="-X 'main.version=$(VERSION)'"
+
 # Default target executed when you run `make`
 all: build
 
@@ -16,7 +21,7 @@ sync:
 build: sync
 	@echo "Building the application..."
 	@mkdir -p $(BUILD_DIR)
-	@go build -o $(BUILD_DIR)/$(BINARY_NAME) $(CMD_PATH)
+	@go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) $(CMD_PATH)
 	@echo "Binary available at $(BUILD_DIR)/$(BINARY_NAME)"
 
 # Runs the application
@@ -37,7 +42,7 @@ ci:
 # Installs the binary to /usr/local/bin
 install: build
 	@echo "Installing $(BINARY_NAME)..."
-	@go install $(CMD_PATH)
+	@go install $(LDFLAGS) $(CMD_PATH)
 	@echo "$(BINARY_NAME) installed successfully"
 
 # Cleans the build artifacts

--- a/cmd/gitx/main.go
+++ b/cmd/gitx/main.go
@@ -4,13 +4,21 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gitxtui/gitx/internal/tui"
 	zone "github.com/lrstanley/bubblezone"
 )
 
+var version = "dev"
+
 func main() {
+	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
+		fmt.Printf("gitx version: %s\n", version)
+		return
+	}
+
 	zone.NewGlobal()
 	defer zone.Close()
 


### PR DESCRIPTION
Closes #20

## What does this PR do?
This PR introduces a `--version` (and `-v`) flag to the application, allowing users to check the current version.

## How was it implemented?
- The `main.go` file was updated to handle the version flag manually using `os.Args`.
- The `Makefile` was updated to automatically inject the latest Git tag into the binary at build time using ldflags.

## Screenshot
As requested in the issue, here is a screenshot of the output:
<img width="452" height="216" alt="image" src="https://github.com/user-attachments/assets/9406a991-6623-4869-bb13-dbb5b5cc59c7" />
