### PR TITLE
feat: add safety warning

### DIFF
--- a/cmd/gitx/main.go
+++ b/cmd/gitx/main.go
@@ -85,9 +85,18 @@ func ensureGitRepo(shouldInit bool) error {
 		return fmt.Errorf("error: not a git repository\nrun gitx -i/--init to initialize a new git repository and open gitx")
 	}
 
+	// Check if the directory is unsafe for git initialization
+	safe, err := git.WarnIfUnsafe(".")
+	if err != nil {
+		return fmt.Errorf("safety check failed: %w", err)
+	}
+	if !safe {
+		return fmt.Errorf("git initialization cancelled by user")
+	}
+
 	// Initialize a new git repository
 	g := &git.GitCommands{}
-	_, err := g.InitRepository(".")
+	_, err = g.InitRepository(".")
 	if err != nil {
 		return fmt.Errorf("failed to initialize git repository: %w", err)
 	}

--- a/cmd/gitx/main.go
+++ b/cmd/gitx/main.go
@@ -140,7 +140,7 @@ func checkInitSafety() (bool, error) {
 func promptInitConfirmation(path, reason string) (bool, error) {
 	fmt.Println()
 	fmt.Println("WARNING: You are about to initialize a git repository in a " + reason + ":")
-	fmt.Printf("  Path: %s\n", path)
+	fmt.Printf("   Path: %s\n", path)
 	fmt.Println()
 	fmt.Println("This may not be what you intended. Initializing git here could cause issues.")
 	fmt.Print("Continue? [y/N]: ")

--- a/cmd/gitx/main.go
+++ b/cmd/gitx/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gitxtui/gitx/internal/git"
@@ -85,8 +88,8 @@ func ensureGitRepo(shouldInit bool) error {
 		return fmt.Errorf("error: not a git repository\nrun gitx -i/--init to initialize a new git repository and open gitx")
 	}
 
-	// Check if the directory is unsafe for git initialization
-	safe, err := git.WarnIfUnsafe(".")
+	// Check if the directory is safe for git initialization
+	safe, err := checkInitSafety()
 	if err != nil {
 		return fmt.Errorf("safety check failed: %w", err)
 	}
@@ -103,4 +106,51 @@ func ensureGitRepo(shouldInit bool) error {
 
 	fmt.Println("Initialized new git repository in current directory")
 	return nil
+}
+
+// unsafeDirs is a list of system directories that should not be initialized as git repositories.
+var unsafeDirs = []string{"/", "/tmp"}
+
+// checkInitSafety verifies if initialization is safe in the current directory.
+// If unsafe, it displays a warning and prompts for confirmation.
+// Returns true if safe or user confirmed, false otherwise.
+func checkInitSafety() (bool, error) {
+	absPath, err := filepath.Abs(".")
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	// Check against unsafe system directories
+	for _, unsafeDir := range unsafeDirs {
+		if absPath == unsafeDir {
+			return promptInitConfirmation(absPath, "system root directory")
+		}
+	}
+
+	// Check against home directory
+	homeDir, err := os.UserHomeDir()
+	if err == nil && absPath == homeDir {
+		return promptInitConfirmation(absPath, "home directory")
+	}
+
+	return true, nil // Safe to proceed
+}
+
+// promptInitConfirmation displays a warning and asks for user confirmation before initialization.
+func promptInitConfirmation(path, reason string) (bool, error) {
+	fmt.Println()
+	fmt.Println("WARNING: You are about to initialize a git repository in a " + reason + ":")
+	fmt.Printf("  Path: %s\n", path)
+	fmt.Println()
+	fmt.Println("This may not be what you intended. Initializing git here could cause issues.")
+	fmt.Print("Continue? [y/N]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("failed to read user input: %w", err)
+	}
+
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y", nil
 }

--- a/internal/git/init.go
+++ b/internal/git/init.go
@@ -1,57 +1,9 @@
 package git
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 )
-
-// UnsafeDirectories is a list of system directories that should not be initialized as git repositories.
-var UnsafeDirectories = []string{"/", "/home", "/tmp"}
-
-// WarnIfUnsafe checks if the given path is potentially unsafe for git initialization.
-// If unsafe, it prints a warning and prompts the user for confirmation.
-// Returns true if the user confirmed or the path is safe, false otherwise.
-func WarnIfUnsafe(path string) (bool, error) {
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return false, fmt.Errorf("failed to resolve path: %w", err)
-	}
-
-	// Check against unsafe system directories
-	for _, unsafe := range UnsafeDirectories {
-		if absPath == unsafe {
-			return promptConfirmation(absPath, "system root directory")
-		}
-	}
-
-	// Check against home directory
-	homeDir, err := os.UserHomeDir()
-	if err == nil && absPath == homeDir {
-		return promptConfirmation(absPath, "home directory")
-	}
-
-	return true, nil // Safe to proceed
-}
-
-// promptConfirmation displays a warning and asks for user confirmation.
-func promptConfirmation(path, reason string) (bool, error) {
-	fmt.Printf("\n⚠️  WARNING: You are about to initialize a git repository in a %s:\n", reason)
-	fmt.Printf("   Path: %s\n\n", path)
-	fmt.Printf("This may not be what you intended. Initializing git here could cause issues.\n")
-	fmt.Printf("Continue? [y/N]: ")
-
-	reader := bufio.NewReader(os.Stdin)
-	response, err := reader.ReadString('\n')
-	if err != nil {
-		return false, fmt.Errorf("failed to read user input: %w", err)
-	}
-
-	response = strings.TrimSpace(strings.ToLower(response))
-	return response == "y", nil
-}
 
 // InitRepository initializes a new Git repository in the specified path.
 func (g *GitCommands) InitRepository(path string) (string, error) {

--- a/internal/git/init.go
+++ b/internal/git/init.go
@@ -1,9 +1,57 @@
 package git
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 )
+
+// UnsafeDirectories is a list of system directories that should not be initialized as git repositories.
+var UnsafeDirectories = []string{"/", "/home", "/tmp"}
+
+// WarnIfUnsafe checks if the given path is potentially unsafe for git initialization.
+// If unsafe, it prints a warning and prompts the user for confirmation.
+// Returns true if the user confirmed or the path is safe, false otherwise.
+func WarnIfUnsafe(path string) (bool, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	// Check against unsafe system directories
+	for _, unsafe := range UnsafeDirectories {
+		if absPath == unsafe {
+			return promptConfirmation(absPath, "system root directory")
+		}
+	}
+
+	// Check against home directory
+	homeDir, err := os.UserHomeDir()
+	if err == nil && absPath == homeDir {
+		return promptConfirmation(absPath, "home directory")
+	}
+
+	return true, nil // Safe to proceed
+}
+
+// promptConfirmation displays a warning and asks for user confirmation.
+func promptConfirmation(path, reason string) (bool, error) {
+	fmt.Printf("\n⚠️  WARNING: You are about to initialize a git repository in a %s:\n", reason)
+	fmt.Printf("   Path: %s\n\n", path)
+	fmt.Printf("This may not be what you intended. Initializing git here could cause issues.\n")
+	fmt.Printf("Continue? [y/N]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("failed to read user input: %w", err)
+	}
+
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y", nil
+}
 
 // InitRepository initializes a new Git repository in the specified path.
 func (g *GitCommands) InitRepository(path string) (string, error) {


### PR DESCRIPTION
Fixes #34

### What this PR does
This PR adds a safety confirmation step before initializing a git repository using `gitx -i/--init`.

When the command is run from potentially sensitive locations (such as `/`, `$HOME`, or `/tmp`), the user is warned and asked to explicitly confirm before proceeding. This helps prevent accidental repository initialization in unintended directories.

### Behavior
- `gitx`
  - Errors out if no git repository exists and suggests using `-i/--init`.

- `gitx -i/--init`
  - Shows a safety warning in sensitive directories and asks for confirmation.
  - Aborts if the user does not confirm.
  - Proceeds with initialization and opens the TUI on confirmation.

### Notes
- The safety check only applies when using the `-i/--init` flag.
- No change in behavior for normal project directories.
- The TUI startup flow remains unchanged and runs only after successful initialization.

Please let me know if you’d like the warning scope or behavior adjusted.
