### PR TITLE
Improve error context for git command helpers

### DIFF
--- a/internal/git/clone.go
+++ b/internal/git/clone.go
@@ -17,7 +17,11 @@ func (g *GitCommands) CloneRepository(repoURL, directory string) (string, error)
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf(
+			"failed to clone repository %s: %w",
+			repoURL,
+			err,
+		)
 	}
 
 	return fmt.Sprintf("Successfully cloned repository: %s", repoURL), nil

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -43,7 +43,11 @@ func (g *GitCommands) ShowCommit(commitHash string) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf(
+			"failed to show commit %s: %w",
+			commitHash,
+			err,
+		)
 	}
 
 	return string(output), nil

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -1,5 +1,9 @@
 package git
 
+import (
+	"fmt"
+)
+
 // DiffOptions specifies the options for the git diff command.
 type DiffOptions struct {
 	Commit1 string
@@ -36,7 +40,10 @@ func (g *GitCommands) ShowDiff(options DiffOptions) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf(
+			"failed to show diff: %w",
+			err,
+		)
 	}
 
 	return string(output), nil

--- a/internal/git/files.go
+++ b/internal/git/files.go
@@ -25,7 +25,11 @@ func (g *GitCommands) BlameFile(filePath string) (string, error) {
 	args := []string{"blame", filePath}
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf(
+			"failed to blame file %s: %w",
+			filePath,
+			err,
+		)
 	}
 
 	return string(output), nil

--- a/internal/git/init.go
+++ b/internal/git/init.go
@@ -14,7 +14,11 @@ func (g *GitCommands) InitRepository(path string) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf(
+			"failed to initialize repository at %s: %w",
+			path,
+			err,
+		)
 	}
 
 	absPath, _ := filepath.Abs(path)

--- a/internal/git/log.go
+++ b/internal/git/log.go
@@ -74,7 +74,10 @@ func (g *GitCommands) ShowLog(options LogOptions) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf(
+			"failed to show log: %w",
+			err,
+		)
 	}
 
 	return string(output), nil

--- a/internal/git/merge.go
+++ b/internal/git/merge.go
@@ -64,7 +64,10 @@ func (g *GitCommands) Rebase(options RebaseOptions) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf(
+			"failed to rebase repository: %w",
+			err,
+		)
 	}
 
 	return string(output), nil

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -35,7 +35,10 @@ func (g *GitCommands) ManageRemote(options RemoteOptions) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf(
+			"failed to manage git remote: %w",
+			err,
+		)
 	}
 
 	return string(output), nil
@@ -55,7 +58,10 @@ func (g *GitCommands) Fetch(remote string, branch string) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf(
+			"failed to fetch from remote: %w",
+			err,
+		)
 	}
 
 	return string(output), nil
@@ -86,7 +92,10 @@ func (g *GitCommands) Pull(options PullOptions) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf(
+			"failed to pull repository: %w",
+			err,
+		)
 	}
 
 	return string(output), nil
@@ -127,7 +136,10 @@ func (g *GitCommands) Push(options PushOptions) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf(
+			"failed to push to remote: %w",
+			err,
+		)
 	}
 
 	return string(output), nil

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 )
@@ -10,7 +11,10 @@ func (g *GitCommands) GetRepoInfo() (repoName string, branchName string, err err
 	// Get the root dir of the repo.
 	repoPath, _, err := g.executeCommand("rev-parse", "--show-toplevel")
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf(
+			"failed to get repository root path: %w",
+			err,
+		)
 	}
 	repoPath = strings.TrimSpace(repoPath)
 	repoName = filepath.Base(repoPath)
@@ -18,7 +22,10 @@ func (g *GitCommands) GetRepoInfo() (repoName string, branchName string, err err
 	// Get the current branch name.
 	branchName, _, err = g.executeCommand("rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf(
+			"failed to get current branch name: %w",
+			err,
+		)
 	}
 	branchName = strings.TrimSpace(branchName)
 
@@ -28,7 +35,10 @@ func (g *GitCommands) GetRepoInfo() (repoName string, branchName string, err err
 func (g *GitCommands) GetGitRepoPath() (repoPath string, err error) {
 	repoPath, _, err = g.executeCommand("rev-parse", "--git-dir")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf(
+			"failed to get git directory path: %w",
+			err,
+		)
 	}
 	repoPath = strings.TrimSpace(repoPath)
 	return repoPath, nil
@@ -38,7 +48,10 @@ func (g *GitCommands) GetGitRepoPath() (repoPath string, err error) {
 func (g *GitCommands) GetUserName() (string, error) {
 	userName, _, err := g.executeCommand("config", "user.name")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf(
+			"failed to get git user name: %w",
+			err,
+		)
 	}
 	return strings.TrimSpace(userName), nil
 }

--- a/internal/git/stage.go
+++ b/internal/git/stage.go
@@ -14,7 +14,7 @@ func (g *GitCommands) AddFiles(paths []string) (string, string, error) {
 
 	output, cmdStr, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), cmdStr, err
+		return string(output), cmdStr, fmt.Errorf("git add failed for paths %v: %w", paths, err)
 	}
 
 	return string(output), cmdStr, nil
@@ -30,7 +30,7 @@ func (g *GitCommands) ResetFiles(paths []string) (string, string, error) {
 
 	output, cmdStr, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), cmdStr, err
+		return string(output), cmdStr, fmt.Errorf("git reset failed for paths %v: %w", paths, err)
 	}
 
 	return string(output), cmdStr, nil
@@ -52,7 +52,7 @@ func (g *GitCommands) RemoveFiles(paths []string, cached bool) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf("git rm failed for paths %v (cached=%v): %w", paths, cached, err)
 	}
 
 	return string(output), nil
@@ -68,7 +68,7 @@ func (g *GitCommands) MoveFile(source, destination string) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf("git mv failed from %q to %q: %w", source, destination, err)
 	}
 
 	return string(output), nil
@@ -106,7 +106,7 @@ func (g *GitCommands) Restore(options RestoreOptions) (string, string, error) {
 
 	output, cmdStr, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), cmdStr, err
+		return string(output), cmdStr, fmt.Errorf("git restore failed for paths %v: %w", options.Paths, err)
 	}
 
 	return string(output), cmdStr, nil
@@ -122,7 +122,7 @@ func (g *GitCommands) Revert(commitHash string) (string, string, error) {
 
 	output, cmdStr, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), cmdStr, err
+		return string(output), cmdStr, fmt.Errorf("git revert failed for commit %s: %w", commitHash, err)
 	}
 
 	return string(output), cmdStr, nil
@@ -138,7 +138,7 @@ func (g *GitCommands) ResetToCommit(commitHash string) (string, string, error) {
 
 	output, cmdStr, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), cmdStr, err
+		return string(output), cmdStr, fmt.Errorf("git reset --hard failed for commit %s: %w", commitHash, err)
 	}
 
 	return string(output), cmdStr, nil

--- a/internal/git/stash.go
+++ b/internal/git/stash.go
@@ -23,7 +23,7 @@ func (g *GitCommands) GetStashes() ([]*Stash, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("git stash list failed: %w", err)
 	}
 
 	rawStashes := strings.Split(strings.TrimSpace(string(output)), "\n")
@@ -101,7 +101,7 @@ func (g *GitCommands) Stash(options StashOptions) (string, string, error) {
 		if strings.Contains(string(output), "No stash entries found") || strings.Contains(string(output), "No stash found") {
 			return "No stashes found.", cmdStr, nil
 		}
-		return string(output), cmdStr, err
+		return string(output), cmdStr, fmt.Errorf("git stash command failed: %w", err)
 	}
 
 	return string(output), cmdStr, nil
@@ -113,7 +113,7 @@ func (g *GitCommands) StashAll() (string, string, error) {
 
 	output, cmdStr, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), cmdStr, err
+		return string(output), cmdStr, fmt.Errorf("git stash push -u failed: %w", err)
 	}
 	return string(output), cmdStr, nil
 }

--- a/internal/git/status.go
+++ b/internal/git/status.go
@@ -1,5 +1,9 @@
 package git
 
+import (
+	"fmt"
+)
+
 // StatusOptions specifies arguments for git status command.
 type StatusOptions struct {
 	Porcelain bool
@@ -14,7 +18,7 @@ func (g *GitCommands) GetStatus(options StatusOptions) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf("git status failed: %w", err)
 	}
 	return string(output), nil
 }

--- a/internal/git/tag.go
+++ b/internal/git/tag.go
@@ -37,7 +37,7 @@ func (g *GitCommands) ManageTag(options TagOptions) (string, error) {
 
 	output, _, err := g.executeCommand(args...)
 	if err != nil {
-		return string(output), err
+		return string(output), fmt.Errorf("git tag command failed: %w", err)
 	}
 
 	return string(output), nil

--- a/internal/git/testing.go
+++ b/internal/git/testing.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -136,15 +137,19 @@ func runGitConfig(dir string) error {
 	cmd := exec.Command("git", "config", "user.name", "Test User")
 	cmd.Dir = dir
 	if err := cmd.Run(); err != nil {
-		return err
+		return fmt.Errorf("git config user.name failed: %w", err)
 	}
 	cmd = exec.Command("git", "config", "user.email", "test@example.com")
 	cmd.Dir = dir
 	if err := cmd.Run(); err != nil {
-		return err
+		return fmt.Errorf("git config user.email failed: %w", err)
 	}
 	// Disable GPG signing for commits
 	cmd = exec.Command("git", "config", "commit.gpgsign", "false")
 	cmd.Dir = dir
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git config commit.gpgsign failed: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
This PR improves error messages returned by git command helper methods by
adding contextual wrapping while preserving the original error.

## What changed
- Standardized error handling across git command methods
- Wrapped command execution errors with descriptive context using `%w`
- No changes to command behavior or return values

## Why
Previously, many failures surfaced as generic errors (e.g. `exit status 128`),
which made it difficult to identify which git operation failed.
Adding context improves debuggability without impacting callers.

## Scope & compatibility
- No API changes
- No behavior changes
- Existing callers continue to work unchanged