### PR TITLE
feat: add separator, line numbers and view toggle

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -12,6 +12,9 @@ type KeyMap struct {
 	// keybindings for changing theme
 	SwitchTheme key.Binding
 
+	// keybindings for diff view
+	ToggleDiffView key.Binding
+
 	// keybindings for navigation
 	FocusNext  key.Binding
 	FocusPrev  key.Binding
@@ -89,7 +92,7 @@ func (k KeyMap) FullHelp() []HelpSection {
 		},
 		{
 			Title:    "Misc",
-			Bindings: []key.Binding{k.SwitchTheme, k.ToggleHelp, k.Escape, k.Quit},
+			Bindings: []key.Binding{k.SwitchTheme, k.ToggleDiffView, k.ToggleHelp, k.Escape, k.Quit},
 		},
 	}
 }
@@ -149,6 +152,12 @@ func DefaultKeyMap() KeyMap {
 		SwitchTheme: key.NewBinding(
 			key.WithKeys("ctrl+t"),
 			key.WithHelp("<c+t>", "switch theme"),
+		),
+
+		// diff view
+		ToggleDiffView: key.NewBinding(
+			key.WithKeys("ctrl+d"),
+			key.WithHelp("<c+d>", "toggle diff view"),
 		),
 
 		// navigation

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -49,6 +49,8 @@ type Model struct {
 	confirmCallback  func(bool) tea.Cmd
 	// New fields for command history
 	CommandHistory []string
+	// Diff view mode: nil = auto (respects threshold), true = split, false = unified
+	forcedDiffViewMode *bool
 }
 
 // initialModel creates the initial state of the application.
@@ -99,22 +101,23 @@ func initialModel() Model {
 	historyVP.SetContent("Command history will appear here...")
 
 	return Model{
-		theme:             Themes[selectedThemeName],
-		themeNames:        themeNames,
-		themeIndex:        indexOf(themeNames, selectedThemeName),
-		focusedPanel:      StatusPanel,
-		activeSourcePanel: StatusPanel,
-		help:              help.New(),
-		helpViewport:      viewport.New(0, 0),
-		showHelp:          false,
-		git:               gc,
-		repoName:          repoName,
-		branchName:        branchName,
-		panels:            panels,
-		mode:              modeNormal,
-		textInput:         ti,
-		descriptionInput:  ta,
-		CommandHistory:    []string{},
+		theme:              Themes[selectedThemeName],
+		themeNames:         themeNames,
+		themeIndex:         indexOf(themeNames, selectedThemeName),
+		focusedPanel:       StatusPanel,
+		activeSourcePanel:  StatusPanel,
+		help:               help.New(),
+		helpViewport:       viewport.New(0, 0),
+		showHelp:           false,
+		git:                gc,
+		repoName:           repoName,
+		branchName:         branchName,
+		panels:             panels,
+		mode:               modeNormal,
+		textInput:          ti,
+		descriptionInput:   ta,
+		CommandHistory:     []string{},
+		forcedDiffViewMode: nil,
 	}
 }
 
@@ -145,6 +148,22 @@ func (m Model) Init() tea.Cmd {
 func (m *Model) nextTheme() {
 	m.themeIndex = (m.themeIndex + 1) % len(m.themeNames)
 	m.theme = Themes[m.themeNames[m.themeIndex]]
+}
+
+// toggleDiffView cycles through diff view modes: auto -> split -> unified -> auto
+func (m *Model) toggleDiffView() {
+	if m.forcedDiffViewMode == nil {
+		// Currently auto - switch to split
+		trueVal := true
+		m.forcedDiffViewMode = &trueVal
+	} else if *m.forcedDiffViewMode {
+		// Currently split - switch to unified
+		falseVal := false
+		m.forcedDiffViewMode = &falseVal
+	} else {
+		// Currently unified - switch to auto
+		m.forcedDiffViewMode = nil
+	}
 }
 
 // panelShortHelp returns a slice of key.Binding for the focused Panel.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -198,6 +198,94 @@ func TestModel_HelpToggle(t *testing.T) {
 	})
 }
 
+func TestModel_ToggleDiffViewKeyCycle(t *testing.T) {
+	m := initialModel()
+
+	pressToggle := func() {
+		updatedModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+		m = updatedModel.(Model)
+	}
+
+	assertMode := func(expected *bool) {
+		t.Helper()
+		if expected == nil {
+			if m.forcedDiffViewMode != nil {
+				t.Fatalf("expected auto mode (nil), got forced=%v", *m.forcedDiffViewMode)
+			}
+			return
+		}
+
+		if m.forcedDiffViewMode == nil {
+			t.Fatalf("expected forced mode %v, got auto mode", *expected)
+		}
+		if *m.forcedDiffViewMode != *expected {
+			t.Fatalf("expected forced mode %v, got %v", *expected, *m.forcedDiffViewMode)
+		}
+	}
+
+	trueVal := true
+	falseVal := false
+
+	assertMode(nil)
+	pressToggle()
+	assertMode(&trueVal)
+	pressToggle()
+	assertMode(&falseVal)
+	pressToggle()
+	assertMode(nil)
+}
+
+func TestRenderAdaptiveDiffView_ModeResolution(t *testing.T) {
+	m := initialModel()
+	theme := m.theme
+	diffContent := "diff --git a/test.py b/test.py\n@@ -1 +1 @@\n-    value = \"a\"   \n+    value = \"b\"   \n"
+
+	t.Run("auto uses split at threshold", func(t *testing.T) {
+		out := renderAdaptiveDiffView(diffContent, splitViewThreshold, theme, nil)
+		if !strings.Contains(out, "│") {
+			t.Fatalf("expected split output with divider")
+		}
+	})
+
+	t.Run("auto uses unified below threshold", func(t *testing.T) {
+		out := renderAdaptiveDiffView(diffContent, splitViewThreshold-1, theme, nil)
+		if out != styleDiffContent(diffContent, theme) {
+			t.Fatalf("expected unified output below split threshold")
+		}
+	})
+
+	t.Run("forced split falls back when too narrow", func(t *testing.T) {
+		forcedSplit := true
+		out := renderAdaptiveDiffView(diffContent, minSplitViewWidth-1, theme, &forcedSplit)
+		if out != styleDiffContent(diffContent, theme) {
+			t.Fatalf("expected unified fallback when forced split is too narrow")
+		}
+	})
+
+	t.Run("forced unified stays unified when wide", func(t *testing.T) {
+		forcedUnified := false
+		out := renderAdaptiveDiffView(diffContent, splitViewThreshold+20, theme, &forcedUnified)
+		if out != styleDiffContent(diffContent, theme) {
+			t.Fatalf("expected unified output in forced unified mode")
+		}
+	})
+}
+
+func TestRenderAdaptiveDiffView_PreservesWhitespaceInSplit(t *testing.T) {
+	m := initialModel()
+	theme := m.theme
+	forcedSplit := true
+	diffContent := "diff --git a/test.py b/test.py\n@@ -1 +1 @@\n-    value = \"a\"   \n+    value = \"b\"   \n"
+
+	out := renderAdaptiveDiffView(diffContent, splitViewThreshold+20, theme, &forcedSplit)
+	if !strings.Contains(out, "    value = \"a\"   ") {
+		t.Fatalf("expected removed line indentation/trailing spaces to be preserved")
+	}
+	if !strings.Contains(out, "    value = \"b\"   ") {
+		t.Fatalf("expected added line indentation/trailing spaces to be preserved")
+	}
+}
+
 func TestModel_MouseFocus(t *testing.T) {
 	zone.NewGlobal()
 	defer zone.Close()

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -220,6 +220,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, keys.SwitchTheme):
 			m.nextTheme()
 
+		case key.Matches(msg, keys.ToggleDiffView):
+			m.toggleDiffView()
+			cmd = m.updateMainPanel()
+			cmds = append(cmds, cmd)
+
 		case key.Matches(msg, keys.FocusNext), key.Matches(msg, keys.FocusPrev),
 			key.Matches(msg, keys.FocusZero), key.Matches(msg, keys.FocusOne),
 			key.Matches(msg, keys.FocusTwo), key.Matches(msg, keys.FocusThree),
@@ -502,7 +507,7 @@ func (m *Model) updateMainPanel() tea.Cmd {
 		// Apply adaptive visual styling: split-view for wide terminals, unified for narrow ones
 		// Calculate right panel width (approximately 65% of total width minus borders)
 		rightPanelWidth := int(float64(m.width)*(1-leftPanelWidthRatio)) - borderWidth - 2
-		content = renderAdaptiveDiffView(content, rightPanelWidth, m.theme)
+		content = renderAdaptiveDiffView(content, rightPanelWidth, m.theme, m.forcedDiffViewMode)
 		return mainContentUpdatedMsg{content: content}
 	}
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -38,6 +38,11 @@ const (
 	lineTypeHunkHeader
 )
 
+const (
+	splitViewThreshold = 80
+	minSplitViewWidth  = 40
+)
+
 // diffRow represents a single row in the structured diff.
 type diffRow struct {
 	lineType   diffLineType
@@ -207,9 +212,8 @@ func renderSplitDiffView(rows []diffRow, columnWidth int, theme Theme) string {
 		return lineNumStyle.Render("")
 	}
 
-	// Helper function to wrap text to fit within contentColWidth.
-	// Tries to wrap on word boundaries; only splits inside a word when it alone
-	// is longer than the available width.
+	// Helper function to wrap text to fit within contentColWidth while preserving
+	// original whitespace exactly (indentation, multiple spaces, trailing spaces).
 	wrapText := func(text string, width int) []string {
 		if width <= 0 {
 			return []string{""}
@@ -223,66 +227,13 @@ func renderSplitDiffView(rows []diffRow, columnWidth int, theme Theme) string {
 			return []string{cleaned}
 		}
 
-		words := strings.Fields(cleaned)
-		if len(words) == 0 {
-			return []string{""}
-		}
-
-		var (
-			lines       []string
-			currentLine []rune
-			lineLen     int
-		)
-
-		flushLine := func() {
-			if len(currentLine) > 0 {
-				lines = append(lines, string(currentLine))
-				currentLine = currentLine[:0]
-				lineLen = 0
+		lines := make([]string, 0, (len(runes)+width-1)/width)
+		for start := 0; start < len(runes); start += width {
+			end := start + width
+			if end > len(runes) {
+				end = len(runes)
 			}
-		}
-
-		for _, w := range words {
-			wordRunes := []rune(w)
-			wordLen := len(wordRunes)
-
-			// If the word itself is longer than the width, we need to hard-wrap it.
-			if wordLen > width {
-				// First, flush any existing content on the current line.
-				flushLine()
-
-				for start := 0; start < wordLen; start += width {
-					end := start + width
-					if end > wordLen {
-						end = wordLen
-					}
-					lines = append(lines, string(wordRunes[start:end]))
-				}
-				continue
-			}
-
-			// If this word (plus a space when needed) doesn't fit on the current line,
-			// start a new line.
-			additional := wordLen
-			if lineLen > 0 {
-				additional++ // space
-			}
-			if lineLen+additional > width {
-				flushLine()
-			}
-
-			if lineLen > 0 {
-				currentLine = append(currentLine, ' ')
-				lineLen++
-			}
-			currentLine = append(currentLine, wordRunes...)
-			lineLen += wordLen
-		}
-
-		flushLine()
-
-		if len(lines) == 0 {
-			return []string{""}
+			lines = append(lines, string(runes[start:end]))
 		}
 		return lines
 	}
@@ -427,9 +378,6 @@ func renderAdaptiveDiffView(content string, width int, theme Theme, forcedViewMo
 	if !strings.Contains(content, "diff --git") && !strings.Contains(content, "@@") {
 		return content
 	}
-
-	const splitViewThreshold = 80
-	const minSplitViewWidth = 40
 
 	useSplitView := false
 	if forcedViewMode != nil {


### PR DESCRIPTION
## Description

Follow-up PR to further enhance the diff viewer with improved layout and usability.

## Changes

- Added centered vertical separator
- Implemented properly aligned line numbers
- Added keybinding to toggle between split and unified views
- Unified view remains the fallback below `splitViewThreshold`

## Result

Cleaner split layout, improved readability and better overall user experience.
